### PR TITLE
Add requirements.txt to define specific version of channels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+django
+channels==3.0.5


### PR DESCRIPTION
The new version of channels does not work (web socket connection is not possible, e.g. '/ws/hobby' is not found). Using the latest stable version of channels fixes this issue.